### PR TITLE
Add area average service and postcode score

### DIFF
--- a/app/api/area-average/route.ts
+++ b/app/api/area-average/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { AreaAverageService } from "@/lib/services/area-average.service";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const postcode = body.postcode as string | undefined;
+    if (!postcode) {
+      return NextResponse.json({ error: "Postcode is required" }, { status: 400 });
+    }
+
+    const res = await fetch(`https://housemetric.co.uk/results?str_input=${encodeURIComponent(postcode)}`);
+    if (!res.ok) {
+      return NextResponse.json({ error: `Failed to fetch postcode data (${res.status})` }, { status: res.status });
+    }
+    const html = await res.text();
+    const service = new AreaAverageService(process.env.GOOGLE_API_KEY!);
+    const areaAverage = await service.extractAverage(html, postcode);
+    return NextResponse.json({ areaAverage });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: e.status ?? 500 });
+  }
+}

--- a/components/property/CurrentValue.tsx
+++ b/components/property/CurrentValue.tsx
@@ -46,8 +46,8 @@ export function CurrentValue() {
     }
   };
 
-  // Mock area average for comparison
-  const areaAverage = 3000; // £3000/m²
+  // Local average price per m²
+  const areaAverage = data.localArea.areaAverage ?? 3000;
   const percentageVsAverage =
     ((data.pricePerSqM - areaAverage) / areaAverage) * 100;
 

--- a/lib/api/aggregate.ts
+++ b/lib/api/aggregate.ts
@@ -39,6 +39,20 @@ async function fetchPropertyFromAPI(url: string): Promise<PropertyData> {
   return propertyData;
 }
 
+async function fetchAreaAverage(postcode: string): Promise<number> {
+  const response = await fetch('/api/area-average', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ postcode }),
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || 'Failed to fetch area average');
+  }
+  const data = await response.json();
+  return data.areaAverage as number;
+}
+
 export async function getAggregatedPropertyData(
   query: string,
 ): Promise<PropertyData> {
@@ -67,6 +81,19 @@ export async function getAggregatedPropertyData(
   try {
     // Fetch property data from our API
     const propertyData = await fetchPropertyFromAPI(query);
+
+    // Try to determine postcode and fetch local average price
+    const postcodeMatch = propertyData.address.match(/[A-Z]{1,2}\d{1,2}[A-Z]?/i);
+    if (postcodeMatch) {
+      try {
+        const areaAverage = await fetchAreaAverage(postcodeMatch[0]);
+        propertyData.localArea.areaAverage = areaAverage;
+        const score = (areaAverage / propertyData.pricePerSqM) * 10;
+        propertyData.valueForMoney = Math.max(0, Math.min(10, parseFloat(score.toFixed(1))));
+      } catch (err) {
+        console.error('Failed to fetch area average', err);
+      }
+    }
 
     // Cache the result (only in browser)
     if (typeof window !== 'undefined') {

--- a/lib/schemas/property.ts
+++ b/lib/schemas/property.ts
@@ -79,6 +79,7 @@ export const LocalAreaSchema = z.object({
     required_error: "ONS area change percentage is required",
   }),
   recentSales: z.array(RecentSaleSchema),
+  areaAverage: z.number().positive().optional(),
   postcodeAverage: PostcodeAverageSchema,
   priceHistory: z
     .array(PriceHistoryEntrySchema)
@@ -242,6 +243,7 @@ export const samplePropertyData: PropertyData = {
         distance: "4 doors down",
       },
     ],
+    areaAverage: 7500,
     postcodeAverage: {
       detached: 1200000,
       semiDetached: 850000,

--- a/lib/services/area-average.service.ts
+++ b/lib/services/area-average.service.ts
@@ -1,0 +1,26 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+export class AreaAverageService {
+  private readonly model;
+  private static readonly TEMPLATE = `You are provided with the HTML source for a Housemetric postcode results page. Extract the mean price per square metre for the postcode {postcode}. Respond ONLY with the numeric value in pounds, no other text.\n\nHTML:\n{html}`;
+
+  constructor(apiKey: string) {
+    const genAI = new GoogleGenerativeAI(apiKey);
+    this.model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+  }
+
+  async extractAverage(html: string, postcode: string): Promise<number> {
+    const prompt = AreaAverageService.TEMPLATE
+      .replace("{postcode}", postcode)
+      .replace("{html}", html);
+
+    const result = await this.model.generateContent(prompt);
+    const response = await result.response;
+    const text = response.text().trim();
+    const match = text.replace(/[,£]/g, "").match(/\d+(?:\.\d+)?/);
+    if (!match) {
+      throw new Error("Failed to parse area average");
+    }
+    return parseFloat(match[0]);
+  }
+}

--- a/lib/services/property-data.service.ts
+++ b/lib/services/property-data.service.ts
@@ -61,6 +61,7 @@ export class PropertyDataService {
       localArea: {
         onsAreaChange: 10.0,
         recentSales: [],
+        areaAverage: 3000,
         postcodeAverage: {
           detached: Math.round((extractedData.price || 0) * 1.5),
           semiDetached: Math.round((extractedData.price || 0) * 1.2),


### PR DESCRIPTION
## Summary
- fetch postcode area averages using Gemini and Housemetric
- compute value for money using that average
- expose new `/api/area-average` endpoint
- show real area average in property UI

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6849a3aef2348320b492acc11008b6bd